### PR TITLE
Change domain dev to test

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,11 +92,11 @@ To run locally, do the usual:
 
     ./manage.py update_metrics
 
-#. Point the ``www.djangoproject.dev``, ``docs.djangoproject.dev`` and ``dashboard.djangoproject.dev``
+#. Point the ``www.djangoproject.test``, ``docs.djangoproject.test`` and ``dashboard.djangoproject.test``
    hostnames with your ``/etc/hosts`` file to ``localhost``/``127.0.0.1``.
    Here's how it could look like::
 
-     127.0.0.1  docs.djangoproject.dev www.djangoproject.dev dashboard.djangoproject.dev
+     127.0.0.1  docs.djangoproject.test www.djangoproject.test dashboard.djangoproject.test
 
    If you're on Mac OS and don't feel like editing the ``/etc/hosts`` file
    manually, there is a great preference pane called `Hosts.prefpane`_. On
@@ -122,8 +122,8 @@ To run locally, do the usual:
 
    This runs both the main site ("www") as well as the
    docs and dashboard site in the same process.
-   Open http://www.djangoproject.dev:8000/, http://docs.djangoproject.dev:8000/
-   or http://dashboard.djangoproject.dev:8000/.
+   Open http://www.djangoproject.test:8000/, http://docs.djangoproject.test:8000/
+   or http://dashboard.djangoproject.test:8000/.
 
 Running the tests
 -----------------

--- a/README.rst
+++ b/README.rst
@@ -92,11 +92,11 @@ To run locally, do the usual:
 
     ./manage.py update_metrics
 
-#. Point the ``www.djangoproject.test``, ``docs.djangoproject.test`` and ``dashboard.djangoproject.test``
+#. Point the ``www.djangoproject.example``, ``docs.djangoproject.example`` and ``dashboard.djangoproject.example``
    hostnames with your ``/etc/hosts`` file to ``localhost``/``127.0.0.1``.
    Here's how it could look like::
 
-     127.0.0.1  docs.djangoproject.test www.djangoproject.test dashboard.djangoproject.test
+     127.0.0.1  docs.djangoproject.example www.djangoproject.example dashboard.djangoproject.example
 
    If you're on Mac OS and don't feel like editing the ``/etc/hosts`` file
    manually, there is a great preference pane called `Hosts.prefpane`_. On
@@ -122,8 +122,8 @@ To run locally, do the usual:
 
    This runs both the main site ("www") as well as the
    docs and dashboard site in the same process.
-   Open http://www.djangoproject.test:8000/, http://docs.djangoproject.test:8000/
-   or http://dashboard.djangoproject.test:8000/.
+   Open http://www.djangoproject.example:8000/, http://docs.djangoproject.example:8000/
+   or http://dashboard.djangoproject.example:8000/.
 
 Running the tests
 -----------------

--- a/djangoproject/fixtures/dev_sites.json
+++ b/djangoproject/fixtures/dev_sites.json
@@ -1,16 +1,16 @@
 [
     {
         "fields": {
-            "domain": "www.djangoproject.dev:8000",
-            "name": "www.djangoproject.dev:8000"
+            "domain": "www.djangoproject.test:8000",
+            "name": "www.djangoproject.test:8000"
         },
         "model": "sites.site",
         "pk": 1
     },
     {
         "fields": {
-            "domain": "docs.djangoproject.dev:8000",
-            "name": "docs.djangoproject.dev:8000"
+            "domain": "docs.djangoproject.test:8000",
+            "name": "docs.djangoproject.test:8000"
         },
         "model": "sites.site",
         "pk": 2

--- a/djangoproject/fixtures/dev_sites.json
+++ b/djangoproject/fixtures/dev_sites.json
@@ -1,16 +1,16 @@
 [
     {
         "fields": {
-            "domain": "www.djangoproject.test:8000",
-            "name": "www.djangoproject.test:8000"
+            "domain": "www.djangoproject.example:8000",
+            "name": "www.djangoproject.example:8000"
         },
         "model": "sites.site",
         "pk": 1
     },
     {
         "fields": {
-            "domain": "docs.djangoproject.test:8000",
-            "name": "docs.djangoproject.test:8000"
+            "domain": "docs.djangoproject.example:8000",
+            "name": "docs.djangoproject.example:8000"
         },
         "model": "sites.site",
         "pk": 2

--- a/djangoproject/settings/dev.py
+++ b/djangoproject/settings/dev.py
@@ -1,10 +1,10 @@
 from .common import *  # noqa
 
 ALLOWED_HOSTS = [
-    'www.djangoproject.test',
-    'djangoproject.test',
-    'docs.djangoproject.test',
-    'dashboard.djangoproject.test',
+    'www.djangoproject.example',
+    'djangoproject.example',
+    'docs.djangoproject.example',
+    'dashboard.djangoproject.example',
 ] + SECRETS.get('allowed_hosts', [])
 
 DEBUG = True
@@ -32,7 +32,7 @@ DOCS_BUILD_ROOT = DATA_DIR.joinpath('djangodocs')
 
 # django-hosts settings
 
-PARENT_HOST = 'djangoproject.test:8000'
+PARENT_HOST = 'djangoproject.example:8000'
 
 # django-push settings
 

--- a/djangoproject/settings/dev.py
+++ b/djangoproject/settings/dev.py
@@ -1,10 +1,10 @@
 from .common import *  # noqa
 
 ALLOWED_HOSTS = [
-    'www.djangoproject.dev',
-    'djangoproject.dev',
-    'docs.djangoproject.dev',
-    'dashboard.djangoproject.dev',
+    'www.djangoproject.test',
+    'djangoproject.test',
+    'docs.djangoproject.test',
+    'dashboard.djangoproject.test',
 ] + SECRETS.get('allowed_hosts', [])
 
 DEBUG = True
@@ -32,7 +32,7 @@ DOCS_BUILD_ROOT = DATA_DIR.joinpath('djangodocs')
 
 # django-hosts settings
 
-PARENT_HOST = 'djangoproject.dev:8000'
+PARENT_HOST = 'djangoproject.test:8000'
 
 # django-push settings
 

--- a/docs/tests.py
+++ b/docs/tests.py
@@ -138,7 +138,7 @@ class SearchFormTestCase(TestCase):
 
     def test_empty_get(self):
         response = self.client.get('/en/dev/search/',
-                                   HTTP_HOST='docs.djangoproject.test:8000')
+                                   HTTP_HOST='docs.djangoproject.example:8000')
         self.assertEqual(response.status_code, 200)
 
 

--- a/docs/tests.py
+++ b/docs/tests.py
@@ -138,7 +138,7 @@ class SearchFormTestCase(TestCase):
 
     def test_empty_get(self):
         response = self.client.get('/en/dev/search/',
-                                   HTTP_HOST='docs.djangoproject.dev:8000')
+                                   HTTP_HOST='docs.djangoproject.test:8000')
         self.assertEqual(response.status_code, 200)
 
 

--- a/releases/tests.py
+++ b/releases/tests.py
@@ -40,12 +40,12 @@ class TestTemplateTags(TestCase):
         self.assertIsInstance(output, SafeString)
         self.assertEqual(
             output,
-            '<a href="http://docs.djangoproject.dev:8000/en/1.8/releases/1.8/">'
+            '<a href="http://docs.djangoproject.test:8000/en/1.8/releases/1.8/">'
             'Online documentation</a>'
         )
         self.assertEqual(
             release_notes('1.8', show_version=True),
-            '<a href="http://docs.djangoproject.dev:8000/en/1.8/releases/1.8/">'
+            '<a href="http://docs.djangoproject.test:8000/en/1.8/releases/1.8/">'
             '1.8 release notes</a>'
         )
 
@@ -54,12 +54,12 @@ class TestTemplateTags(TestCase):
         self.assertIsInstance(output, SafeString)
         self.assertEqual(
             output,
-            '<a href="http://docs.djangoproject.dev:8000/en/1.10/releases/1.10/">'
+            '<a href="http://docs.djangoproject.test:8000/en/1.10/releases/1.10/">'
             'Online documentation</a>'
         )
         self.assertEqual(
             release_notes('1.10', show_version=True),
-            '<a href="http://docs.djangoproject.dev:8000/en/1.10/releases/1.10/">'
+            '<a href="http://docs.djangoproject.test:8000/en/1.10/releases/1.10/">'
             '1.10 release notes</a>'
         )
 

--- a/releases/tests.py
+++ b/releases/tests.py
@@ -40,12 +40,12 @@ class TestTemplateTags(TestCase):
         self.assertIsInstance(output, SafeString)
         self.assertEqual(
             output,
-            '<a href="http://docs.djangoproject.test:8000/en/1.8/releases/1.8/">'
+            '<a href="http://docs.djangoproject.example:8000/en/1.8/releases/1.8/">'
             'Online documentation</a>'
         )
         self.assertEqual(
             release_notes('1.8', show_version=True),
-            '<a href="http://docs.djangoproject.test:8000/en/1.8/releases/1.8/">'
+            '<a href="http://docs.djangoproject.example:8000/en/1.8/releases/1.8/">'
             '1.8 release notes</a>'
         )
 
@@ -54,12 +54,12 @@ class TestTemplateTags(TestCase):
         self.assertIsInstance(output, SafeString)
         self.assertEqual(
             output,
-            '<a href="http://docs.djangoproject.test:8000/en/1.10/releases/1.10/">'
+            '<a href="http://docs.djangoproject.example:8000/en/1.10/releases/1.10/">'
             'Online documentation</a>'
         )
         self.assertEqual(
             release_notes('1.10', show_version=True),
-            '<a href="http://docs.djangoproject.test:8000/en/1.10/releases/1.10/">'
+            '<a href="http://docs.djangoproject.example:8000/en/1.10/releases/1.10/">'
             '1.10 release notes</a>'
         )
 


### PR DESCRIPTION
Changed domain name from `djangoproject.dev` to `djangoproject.test` according to RFC2606.